### PR TITLE
Support flake8 2.6.0+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,9 @@ Changes
 ''''''''''''''''''''''''
 
 * Fixed reading from stdin
+* Fixed not being able to run when pycodestyle, not pep8, is installed (pep8
+  has been renamed to pycodestyle and flake8 2.6.0+ doesn't trigger pep8
+  installation anymore)
 
 0.1.2
 '''''

--- a/flake8_strict.py
+++ b/flake8_strict.py
@@ -5,7 +5,11 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import enum
 import itertools
 import sys
-import pep8
+
+try:
+    import pycodestyle
+except ImportError:
+    import pep8 as pycodestyle
 
 # A conscious decision has been made to use an (to the best of my knowledge)
 # undocumented and somewhat private lib2to3 package here.
@@ -50,7 +54,7 @@ _driver = Driver(
 
 def _process_file(filename):
     if filename == 'stdin':
-        code = pep8.stdin_get_value()
+        code = pycodestyle.stdin_get_value()
     else:
         with open(filename, 'rt') as f:
             code = f.read()


### PR DESCRIPTION
pep8 has been renamed to pycodestyle[1] and the most recent flake8
version depends on pycodestyle rather than on pep8[2], we need this
conditional import to support both older and more recent installations.

[1] https://github.com/PyCQA/pycodestyle/issues/466
[2] https://gitlab.com/pycqa/flake8/commit/0a6ecad8061c338b03709af0dc3924a25082246d

Example of related failure: https://travis-ci.org/smarkets/flake8-strict/builds/124444547 (I triggered one subbuild today to demonstrate the issue)
