### PR TITLE
Treat function calls with one argument more reasonably

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,7 @@ Changes
   has been renamed to pycodestyle and flake8 2.6.0+ doesn't trigger pep8
   installation anymore)
 * Added support for set, list and dict literals and comprehensions
+* Function calls with single, multi-line arguments are now treated more reasonably
 
 0.1.2
 '''''

--- a/flake8_strict.py
+++ b/flake8_strict.py
@@ -121,7 +121,11 @@ def _process_trailer(trailer):
     # trailer: '(' [arglist] ')' | '[' subscriptlist ']' | '.' NAME
     children = trailer.children
     if len(children) == 3:
-        return _process_parameters(trailer)
+        middle = children[1]
+        if pytree.type_repr(middle.type) == 'atom':
+            return _process_atom(middle)
+        else:
+            return _process_parameters(trailer)
     else:
         return []
 

--- a/test_data.py
+++ b/test_data.py
@@ -106,6 +106,38 @@ a = {
     for x in range(1)
 }
 
+
+f3([
+    '11',
+    '22',
+])
+
+f3({
+    '11',
+    '22',
+})
+
+f3({
+    '11': 11,
+    '22': 22,
+})
+
+f3([
+    x
+    for x in range(1)
+])
+
+f3({
+    x
+    for x in range(1)
+})
+
+f3({
+    x: x
+    for x in range(1)
+})
+
+
 kwargs = {}
 
 f5('-o',  # S100


### PR DESCRIPTION
In our codebase there are quite a few places where we call a function
with one, multi-line argument (a dictionary for example). Previous
flake8-strict versions would enforce the following format:

``` python
function(
    {
        'key1': 'value1',
        'key2': 'value2',
        'key3': 'value3',
    },
)
```

After this change the following is allowed:

``` python
function({
    'key1': 'value1',
    'key2': 'value2',
    'key3': 'value3',
})
```

The first form is still allowed but it's possible it'll be disallowed in
the future.
#4 and #5 are required by this patch.
