### PR TITLE
Be able to run flake8-strict on its own codebase

### DIFF
--- a/test.py
+++ b/test.py
@@ -18,10 +18,10 @@ def test_processing():
             for error_code in match.group(1).split():
                 expected_errors.add((lineno + 1, error_code))
 
-    actual_errors = set(
+    actual_errors = {
         (line, error_code.name)
-        for line, column, error_code in _process_code(code),
-    )
+        for line, column, error_code in _process_code(code)
+    }
 
     not_caught = expected_errors - actual_errors
     false_negatives = actual_errors - expected_errors


### PR DESCRIPTION
The issue is that the lib2to3 parser doesn't seem to handle code like
this:

```
some_symbol(
    some generator,
)
```

The error:

```
(...)
  File "/home/travis/virtualenv/python2.7.9/lib/python2.7/site-packages/flake8_strict.py", line 65, in _process_code
    tree = _driver.parse_string(code)
  File "/opt/python/2.7.9/lib/python2.7/lib2to3/pgen2/driver.py", line 106, in parse_string
    return self.parse_tokens(tokens, debug)
  File "/opt/python/2.7.9/lib/python2.7/lib2to3/pgen2/driver.py", line 71, in parse_tokens
    if p.addtoken(type, value, (prefix, start)):
  File "/opt/python/2.7.9/lib/python2.7/lib2to3/pgen2/parse.py", line 159, in addtoken
    raise ParseError("bad input", type, value, context)
lib2to3.pgen2.parse.ParseError: bad input: type=8, value=')', context=('\n    ', (24, 4))
```

Ironically enough without the trailing comma it works fine but we don't like
not having trailing commas so let's just switch to a set comprehension.

The issue that causes this is a limitation of lib2to3 and will be
documented separately.

Closes https://github.com/smarkets/flake8-strict/issues/9
