### PR TITLE
Fixing ParseError if newline is omitted at the end of a file

### DIFF
--- a/flake8_strict.py
+++ b/flake8_strict.py
@@ -62,7 +62,9 @@ def _process_file(filename):
 
 
 def _process_code(code):
-    tree = _driver.parse_string(code)
+    tree = _driver.parse_string(
+        '%s%s' % (code, '\n' if code and code[-1] != '\n' else ''),
+    )
     return _process_tree(tree)
 
 

--- a/test.py
+++ b/test.py
@@ -9,7 +9,7 @@ def test_processing():
     with open('test_data.py', 'rt') as f:
         code = f.read()
 
-    code = code.strip() + '\n'
+    code = code.strip()
 
     expected_errors = set()
     for lineno, line in enumerate(code.splitlines()):


### PR DESCRIPTION
The fix contains:
  - adding newline if it is not in the string to parse
  - removed newline character from test_data as it was hiding the problem

Fix #18 