### PR TITLE
Fix trailing comma after *args/**kwargs in Python3.6+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,11 @@ Above 1.0.0, given a version number MAJOR.MINOR.PATCH:
 Changes
 -------
 
+0.1.7 (not yet released)
+''''''''''''''''''''''''
+
+* Fixed trailing comma after *args/**kwargs for Python 3.6+ (issue #25)
+
 0.1.6
 '''''
 

--- a/flake8_strict.py
+++ b/flake8_strict.py
@@ -108,7 +108,7 @@ def _process_parameters(parameters):
 
     # We only accept lack of trailing comma in case of the parameter
     # list containing any use of * or ** as adding the trailing comma
-    # is a syntax error.
+    # is a syntax error (in Python versions below 3.6).
     no_variadic_arguments = all(
         [
             element.type not in (token.STAR, token.DOUBLESTAR)
@@ -116,7 +116,10 @@ def _process_parameters(parameters):
         ]
     ) and not _is_unpacking_element(last_element)
 
-    if last_element.type != token.COMMA and no_variadic_arguments:
+    # We're allowed trailing commas here if we're on Python 3.6 +.
+    variadic_comma_allowed = no_variadic_arguments or sys.version_info >= (3, 6)
+
+    if last_element.type != token.COMMA and variadic_comma_allowed:
         yield _error(last_element, ErrorCode.S101)
 
 

--- a/test.py
+++ b/test.py
@@ -1,4 +1,7 @@
+import platform
 import re
+
+from distutils.version import LooseVersion
 
 from nose.tools import eq_
 
@@ -13,10 +16,18 @@ def test_processing():
 
     expected_errors = set()
     for lineno, line in enumerate(code.splitlines()):
+        include_errors = True
         match = re.search(r'  # (.*)$', line.strip('\n'))
         if match:
-            for error_code in match.group(1).split():
-                expected_errors.add((lineno + 1, error_code))
+            for code_or_version in match.group(1).split():
+                version_match = re.search(r'py(.*):', code_or_version)
+                if version_match:
+                    include_errors = (
+                        LooseVersion(platform.python_version()) >=
+                        LooseVersion(version_match.group(1))
+                    )
+                elif include_errors:
+                    expected_errors.add((lineno + 1, code_or_version))
 
     actual_errors = {
         (line, error_code.name)

--- a/test_data.py
+++ b/test_data.py
@@ -23,20 +23,20 @@ def f3(
 
 def f4(
     a,
-    *args
+    *args  # py3.6: S101
 ):
     pass
 
 
 def f5(
     b,
-    **kwargs
+    **kwargs  # py3.6: S101
 ):
     pass
 
 def f6(
     *,
-    d
+    d  # py3.6: S101
 ):
     pass
 
@@ -157,12 +157,12 @@ f5(
 
 f4(
     3,
-    *[1, 2]
+    *[1, 2]  # py3.6: S101
 )
 
 f5(
     3,
-    **{
+    **{  # py3.6: S101
         'a': 3,
     }
 )


### PR DESCRIPTION
We purposefully ignore a trailing comma after *args/**kwargs, as it
causes a syntax error in Python versions below 3.6. This now enforces
the trailing comma provided we meet the necessary Python version.

Some minor test refactoring was necessary to support versioned test
cases.

Fixes: #25 