### PR TITLE
 Add back support for trailing commas after *args/**kwargs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ python:
   - "pypy3"
   - "pypy3.3-5.2-alpha1"
 install:
+  - pip install --upgrade setuptools
   - pip install nose flake8
   - pip install .
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.5-dev"
+  - "3.6"
   - "nightly"
   - "pypy"
   - "pypy-5.3"

--- a/flake8_strict.py
+++ b/flake8_strict.py
@@ -12,18 +12,19 @@ try:
 except ImportError:
     import pep8 as pycodestyle
 
-# A conscious decision has been made to use an (to the best of my knowledge)
-# undocumented and somewhat private lib2to3 package here.
-#
-# I trust the automated test suite to catch trivial issues if any backwards
-# incompatible changes are made to lib2to3 that affect us so we can fix them.
-#
-# Jakub
 
-from lib2to3 import pytree
-from lib2to3.pgen2.driver import Driver
-from lib2to3.pgen2 import token
-from lib2to3.pygram import python_grammar_no_print_statement
+# Use lib2to3 fork from black (https://github.com/ambv/black.git)
+try:
+    from blib2to3 import pytree
+    from blib2to3.pgen2.driver import Driver
+    from blib2to3.pgen2 import token
+    from blib2to3.pygram import python_grammar_no_print_statement
+except ImportError:
+    from lib2to3 import pytree
+    from lib2to3.pgen2.driver import Driver
+    from lib2to3.pgen2 import token
+    from lib2to3.pygram import python_grammar_no_print_statement
+
 
 __version__ = '0.1.9'
 
@@ -171,9 +172,9 @@ def _process_atom(atom):
 
     # Enforcing trailing commas in list/dict/set comprehensions seems too strict
     # so we won't do it for now even if it is syntactically allowed.
-    has_comprehension_inside = 'comp_for' in {
+    has_comprehension_inside = not {'comp_for', 'old_comp_for'}.isdisjoint({
         pytree.type_repr(node.type) for node in maker.children
-    }
+    })
     if last_maker_element.type != token.COMMA and not has_comprehension_inside:
         yield _error(last_maker_element, ErrorCode.S101)
 

--- a/flake8_strict.py
+++ b/flake8_strict.py
@@ -110,7 +110,7 @@ def _process_parameters(parameters):
 
     # We only accept lack of trailing comma in case of the parameter
     # list containing any use of * or ** as adding the trailing comma
-    # is a syntax error.
+    # is a syntax error (in Python versions below 3.6).
     no_variadic_arguments = all(
         [
             element.type not in (token.STAR, token.DOUBLESTAR)
@@ -118,7 +118,10 @@ def _process_parameters(parameters):
         ]
     ) and not _is_unpacking_element(last_element)
 
-    if last_element.type != token.COMMA and no_variadic_arguments:
+    # We're allowed trailing commas here if we're on Python 3.6 +.
+    variadic_comma_allowed = no_variadic_arguments or sys.version_info >= (3, 6)
+
+    if last_element.type != token.COMMA and variadic_comma_allowed:
         yield _error(last_element, ErrorCode.S101)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,4 +3,4 @@ universal = 1
 
 [flake8]
 max_line_length = 100
-exclude = .tox,.git,test_data.py
+exclude = .tox,.git,test_data_py2_py3.py,test_data_py36.py

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup_arguments = dict(
     ],
     py_modules=['flake8_strict'],
     install_requires=[
+        'black; python_version>="3.6"',
         'enum-compat',
         'flake8',
         'setuptools',

--- a/test.py
+++ b/test.py
@@ -1,22 +1,34 @@
+import platform
 import re
+import sys
+
+from distutils.version import LooseVersion
 
 from nose.tools import eq_
 
 from flake8_strict import _process_code
 
 
-def test_processing():
-    with open('test_data.py', 'rt') as f:
+def _test_processing(test_data_path):
+    with open(test_data_path, 'rt') as f:
         code = f.read()
 
     code = code.strip()
 
     expected_errors = set()
     for lineno, line in enumerate(code.splitlines()):
+        include_errors = True
         match = re.search(r'  # (.*)$', line.strip('\n'))
         if match:
-            for error_code in match.group(1).split():
-                expected_errors.add((lineno + 1, error_code))
+            for code_or_version in match.group(1).split():
+                version_match = re.search(r'py(.*):', code_or_version)
+                if version_match:
+                    include_errors = (
+                        LooseVersion(platform.python_version()) >=
+                        LooseVersion(version_match.group(1))
+                    )
+                elif include_errors:
+                    expected_errors.add((lineno + 1, code_or_version))
 
     actual_errors = {
         (line, error_code.name)
@@ -27,3 +39,14 @@ def test_processing():
     false_negatives = actual_errors - expected_errors
 
     eq_((not_caught, false_negatives), (set(), set()))
+
+
+def test_processing_py2_py3():
+    """Test the library against Python 2/3 compatible syntaxes."""
+    _test_processing('test_data_py2_py3.py')
+
+
+if sys.version_info >= (3, 6):
+    def test_processing_py36():
+        """Test the library against Python 3.6+ specific syntaxes."""
+        _test_processing('test_data_py36.py')

--- a/test_data_py2_py3.py
+++ b/test_data_py2_py3.py
@@ -23,20 +23,20 @@ def f3(
 
 def f4(
     a,
-    *args
+    *args  # py3.6: S101
 ):
     pass
 
 
 def f5(
     b,
-    **kwargs
+    **kwargs  # py3.6: S101
 ):
     pass
 
 def f6(
     *,
-    d
+    d  # py3.6: S101
 ):
     pass
 
@@ -157,12 +157,12 @@ f5(
 
 f4(
     3,
-    *[1, 2]
+    *[1, 2]  # py3.6: S101
 )
 
 f5(
     3,
-    **{
+    **{  # py3.6: S101
         'a': 3,
     }
 )

--- a/test_data_py36.py
+++ b/test_data_py36.py
@@ -1,0 +1,13 @@
+def f0(
+    b,
+    **kwargs,
+):
+    """Test compatibility with comma after **kwargs."""
+    pass
+
+
+def f1():
+    """Test compatibility with f-strings"""
+    hello = 'hello'
+    world = 'world'
+    hello_world = f'{hello} {world}'


### PR DESCRIPTION
This also allows usage of new python features, such as f-strings, without flake8-strict having problems.